### PR TITLE
解决页面中`Archives, About, Tags`的i18n问题

### DIFF
--- a/layout/_partial/_widget/tags.swig
+++ b/layout/_partial/_widget/tags.swig
@@ -1,6 +1,6 @@
 {% if theme.widget.Tags %}
     <section id="tags" class="widget-area widget_tags">
-        <h3 class="widget-title">Tags</h3>
+        <h3 class="widget-title">{{ __('menu.tags') }}</h3>
         {{ list_tags({show_count: true, amount: 10, orderby: 'count'}) }}
     </section>
 {% endif %}

--- a/layout/_partial/header.swig
+++ b/layout/_partial/header.swig
@@ -10,11 +10,7 @@
                     <li class="menu-item">
                         <a href="{{ url_for(path) }}">
                             {% set itemName = 'menu.' + name.toLowerCase() %}
-                            {% if itemName.startsWith('menu') %}
-                                {{ name }}
-                            {% else %}
-                                {{ __(itemName) }}
-                            {% endif %}
+                            {{ __(itemName) }}
                         </a>
                     </li>
                 {% endfor %}


### PR DESCRIPTION
我不明白`_partial/header.swig`中13行`if`的作用，不过看上去它永远为真，这样header中的栏目永远都是英语，实际测试也是如此。